### PR TITLE
Remove duplicate category for tab-bar which breaks due to Nuke's 50 character limit.

### DIFF
--- a/app.py
+++ b/app.py
@@ -295,7 +295,7 @@ class NukeWriteNode(tank.platform.Application):
                 pn
             )
             self.engine.register_command(
-                "%s [Flow Production Tracking]" % profile_name,
+                profile_name,
                 cb_fn,
                 dict(
                     type="node",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc452e60-f00f-492e-a2a4-344960437c72)
